### PR TITLE
fix warning about deprecated sleep_ms

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ pub fn every(interval: Duration) -> Stream<Duration> {
                 sink.send(passed);
                 last = last + passed;
             } else {
-                thread::sleep_ms(togo.num_milliseconds() as u32);
+                thread::sleep(togo.to_std().unwrap());
             }
         }
     });
@@ -82,6 +82,7 @@ pub fn integrate<A, B, F>(a: &Signal<A>, initial: B, dt: Duration, f: F) -> Sign
 #[cfg(test)]
 mod test {
     use std::thread;
+    use std::time;
     use std::fmt::Debug;
     use carboxyl::{ Signal, Sink };
     use time::{ Duration, Tm };
@@ -116,7 +117,7 @@ mod test {
     fn consistent_with_sleep_ms<F: Fn() -> Signal<Tm>>(f: F) {
         let t0 = f().sample();
         for n in 0..5 {
-            thread::sleep_ms(n);
+            thread::sleep(time::Duration::from_millis(n));
             let dt = f().sample() - t0;
             assert!(dt > Duration::milliseconds(n as i64));
         }


### PR DESCRIPTION
This fixes the warning, but inexplicably causes the tests to fail more often.

[Here](http://fooplot.com/#W3sidHlwZSI6MywiZXEiOltbIjUiLCIzMSJdLFsiMTAiLCIzNyJdLFsiMTUiLCI5Il0sWyIyMCIsIjYiXSxbIjI1IiwiNSJdLFsiMzAiLCI0Il0sWyIzNSIsIjMiXSxbIjQwIiwiNSJdLFsiNDUiLCIyIl0sWyI1MCIsIjYiXSxbIjYwIiwiNSJdLFsiNzAiLCI2Il0sWyI4MCIsIjYiXSxbIjkwIiwiMiJdLFsiMTAwIiwiMCJdXSwiY29sb3IiOiIjMDAwMDAwIn0seyJ0eXBlIjozLCJlcSI6W1siNSIsIjY3Il0sWyIxMCIsIjQ3Il0sWyIxNSIsIjIzIl0sWyIyMCIsIjExIl0sWyIyNSIsIjYiXSxbIjMwIiwiNSJdLFsiMzUiLCI0Il0sWyI0MCIsIjUiXSxbIjQ1IiwiNiJdLFsiNTAiLCIzIl0sWyI2MCIsIjUiXSxbIjcwIiwiMyJdLFsiODAiLCIzIl0sWyI5MCIsIjIiXSxbIjEwMCIsIjEiXV0sImNvbG9yIjoiI0ZGMDAwMCJ9LHsidHlwZSI6MTAwMCwid2luZG93IjpbIjAiLCIxMDUiLCItNSIsIjEwMCJdfV0-) is a plot visualizing the difference. I have modified the `every_timing` test to allow different tolerance levels instead of the hard-coded 5%, and the plot shows that the gap between the two events is off by X percent Y percent of the time. I ran the tests 100 times per data point. master is in black, this branch is in red.